### PR TITLE
Yes, we end up just setting an extra property on the relation

### DIFF
--- a/lib/relation.js
+++ b/lib/relation.js
@@ -285,6 +285,7 @@ _.extend(BookshelfRelation.prototype, {
         groupedKey = this.isThrough() ? formatted[this.key('throughForeignKey')] : formatted[this.key('foreignKey')];
       }
       var relation = model.relations[relationName] = this.relatedInstance(grouped[groupedKey]);
+      relation.all = grouped[groupedKey];
       relation.relatedData = this;
       if (this.isJoined()) _.extend(relation, pivotHelpers);
     }


### PR DESCRIPTION
After digging into this all over the place, I decided the simplest solution was to just expose the output of the query on the relation. This object looks like:

``` js
{
  models: [ ... ],
  _byId: [ ... ],
  all: [ ... ],
  relatedData: { ... }
}
```

Which is why I decided this was the best place to tuck this property.

Interestingly, `_byId` has a... bug?, in that it'll use the current _connection id_ as well as the actual object's id to index by, so `relation._byId[450]` and `relation._byId['__cid1']` both work.
